### PR TITLE
Create a custom fake simple plugin for testing

### DIFF
--- a/pkg/package.go
+++ b/pkg/package.go
@@ -210,7 +210,7 @@ func (rp RizinPackage) downloadGit(artifactsPath string) error {
 
 // Download the source code of a package and extract it in the provided path
 func (rp RizinPackage) Download(baseArtifactsPath string) error {
-	log.Printf("Downloading package %s...\n", rp.PackageName)
+	log.Printf("Downloading package %s... from '%s'", rp.PackageName, rp.PackageSource.URL)
 	artifactsPath := rp.artifactsPath(baseArtifactsPath)
 	err := os.MkdirAll(artifactsPath, os.FileMode(0755))
 	if err != nil {
@@ -249,6 +249,12 @@ func (rp RizinPackage) buildMeson(site Site) error {
 	cmd.Dir = srcPath
 	cmd.Stdout = log.Writer()
 	cmd.Stderr = log.Writer()
+
+	log.Printf("Running meson setup:")
+	log.Printf("\tdir: %s", srcPath)
+	log.Printf("\targs: %s", strings.Join(args, " "))
+
+
 	if err := cmd.Run(); err != nil {
 		return err
 	}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -4,5 +4,15 @@ import "strings"
 
 func GetMajorMinorVersion(version string) string {
 	splits := strings.SplitN(version, ".", 3)
-	return splits[0] + "." + splits[1]
+	var major, minor string
+
+	major = splits[0]
+	if len(splits) < 2 {
+		// If there is no minor version, return the major version with a ".0"
+		minor = "0"
+	} else {
+		minor = splits[1]
+	}
+
+	return major + "." + minor
 }

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -1,0 +1,25 @@
+package pkg
+
+import "testing"
+
+func TestGetMajorMinorVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{"1.2.3", "1.2"},
+		{"10.20.30", "10.20"},
+		{"0.1.2", "0.1"},
+		{"5.6", "5.6"}, // Edge case with no patch version
+		{"1", "1.0"},   // Edge case with only major version
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			got := GetMajorMinorVersion(tt.version)
+			if got != tt.want {
+				t.Errorf("GetMajorMinorVersion(%q) = %q; want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}

--- a/simpleplugin/meson.build
+++ b/simpleplugin/meson.build
@@ -1,0 +1,13 @@
+project('simple_project', 'c')
+
+rz_core_dep = dependency('rz_core')
+plugins_dir = get_option('rizin_plugdir')
+message('Plugins install directory: ' + plugins_dir)
+
+library(
+  'plugin',
+  ['plugin.c'],
+  dependencies: [rz_core_dep],
+  install: true,
+  install_dir: plugins_dir,
+)

--- a/simpleplugin/meson_options.txt
+++ b/simpleplugin/meson_options.txt
@@ -1,0 +1,5 @@
+option(
+  'rizin_plugdir',
+  type: 'string',
+  description: 'Rizin plugin directory',
+)

--- a/simpleplugin/plugin.c
+++ b/simpleplugin/plugin.c
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2018-2023 Giovanni Dante Grazioli <deroad@libero.it>
+// SPDX-FileCopyrightText: 2025 Eyad Issa <eyadlorenzo@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <rz_analysis.h>
+#include <rz_cmd.h>
+#include <rz_cons.h>
+#include <rz_core.h>
+#include <rz_lib.h>
+#include <rz_types.h>
+
+static bool rz_cmd_init(RzCore *core) {
+  // no-op plugin, does nothing
+  RZ_LOG_INFO("Initializing simple plugin\n");
+  return true;
+}
+
+static bool rz_cmd_fini(RzCore *core) {
+  // no-op plugin, does nothing
+  RZ_LOG_INFO("Finalizing simple plugin\n");
+  return true;
+}
+
+RzCorePlugin rz_core_plugin_example = {
+    .name = "simple-plugin",
+    .desc = "A simple no-op plugin for Rizin",
+    .license = "BSD-3-Clause",
+    .init = rz_cmd_init,
+    .fini = rz_cmd_fini,
+};
+
+#ifdef _MSC_VER
+#define _RZ_API __declspec(dllexport)
+#else
+#define _RZ_API __attribute__((visibility("default")))
+#endif
+
+#ifndef CORELIB
+_RZ_API RzLibStruct rizin_plugin = {
+    .type = RZ_LIB_TYPE_CORE,
+    .data = &rz_core_plugin_example,
+    .version = RZ_VERSION,
+};
+#endif


### PR DESCRIPTION
Using a real plugin means:
1. we need to be online during testing
2. if the plugin has a different version from rizin
   on the machine often it won't event compile

This commit introduces a fake plugin in the
simpleplugin directory. During testing, an HTTP
server is spawned. The .tar.gz is created and
served on-the-fly to every test that asks for it.
