### PR TITLE
Add periodic update checks and do not exec rizin multiple times

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,43 +37,46 @@ jobs:
             meson_options: -Dportable=true -Db_vscrt=static_from_buildtype
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install meson ninja
       - uses: seanmiddleditch/gha-setup-vsdevenv@master
         if: matrix.os == 'windows-latest'
+      - name: Setup ccache/sccache
+        uses: hendrikmuhs/ccache-action@v1.2
       - name: Install Rizin
         run: |
           git clone https://github.com/rizinorg/rizin
           cd rizin
           git checkout ${{ env.RIZIN_VERSION }}
-          meson --buildtype=release --prefix=${{ matrix.prefix }} ${{ matrix.meson_options }} build
-          meson compile ${{ matrix.os == 'windows-latest' && '-j1' || '' }} -C build
+          meson setup --buildtype=release --prefix=${{ matrix.prefix }} ${{ matrix.meson_options }} build
+          ninja ${{ matrix.os == 'windows-latest' && '-j1' || '' }} -C build
           ${{ matrix.sudo }} meson install -C build
           cd ..
       - name: Add rizin dir to PATH
         if: matrix.os == 'windows-latest'
         run: |
           echo "D:/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - name: Set up Golang
+      - name: Set up Golang ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
-      - name: Check out code into the Go module directory
+      - name: Check out source code
         uses: actions/checkout@v4
       - name: Run unit tests
         run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Build the Go binary
         run: go build -v -o rz-pm .
-      - name: Make sure jsdec is present in the database
+
+      - name: "Test: make sure jsdec is present in the database"
         run: ./rz-pm --debug list | grep -q 'Converts asm to pseudo-C code'
-      - name: Install jsdec
+      - name: "Test: Install jsdec"
         run: ./rz-pm --debug install jsdec
-      - name: Check jsdec
+      - name: "Test: Check jsdec"
         run: ls $(rizin -H RZ_USER_PLUGINS) | grep core_pdd

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,12 +68,12 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
       - name: Run unit tests
-        run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic
+        run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Build the Go binary
-        run: go build
+        run: go build -v -o rz-pm .
       - name: Make sure jsdec is present in the database
-        run: ./rz-pm list | grep -q 'Converts asm to pseudo-C code'
+        run: ./rz-pm --debug list | grep -q 'Converts asm to pseudo-C code'
       - name: Install jsdec
-        run: ./rz-pm install jsdec
+        run: ./rz-pm --debug install jsdec
       - name: Check jsdec
         run: ls $(rizin -H RZ_USER_PLUGINS) | grep core_pdd

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,9 +6,9 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: "1.22"
-  RIZIN_VERSION: "v0.8.0"
-  PYTHON_VERSION: "3.10"
+  GO_VERSION: "1.24"
+  RIZIN_VERSION: "v0.8.1"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   build:
@@ -62,13 +62,14 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "D:/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Check out source code
+        uses: actions/checkout@v4
       - name: Set up Golang ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
         id: go
-      - name: Check out source code
-        uses: actions/checkout@v4
       - name: Run unit tests
         run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Build the Go binary

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func listPackages(c *cli.Context, installed bool) error {
 		packages, err = site.ListAvailablePackages()
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list packages: %w", err)
 	}
 
 	green := color.New(color.Bold, color.FgGreen).SprintFunc()
@@ -257,7 +257,7 @@ func installPackages(c *cli.Context) error {
 
 		err = site.InstallPackage(pkg)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to install package: %w", err)
 		}
 	}
 	return nil
@@ -292,7 +292,7 @@ func uninstallPackages(c *cli.Context) error {
 
 		err = site.UninstallPackage(pkg)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to uninstall package: %w", err)
 		}
 	}
 	return nil
@@ -323,7 +323,7 @@ func cleanPackage(c *cli.Context) error {
 
 	err = site.CleanPackage(pkg)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to clean package: %w", err)
 	}
 	fmt.Printf("Package %s build artifacts have been cleaned.\n", pkg.Name())
 	return nil

--- a/pkg/database.go
+++ b/pkg/database.go
@@ -27,7 +27,13 @@ func InitDatabase(path string, rizinVersion string) (Database, error) {
 	firstTime := false
 
 	// if path does not exist, create it and force a db update
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	_, err := os.Stat(path)
+	if err != nil {
+
+		if !os.IsNotExist(err) {
+			return Database{}, fmt.Errorf("failed to access database directory: %w", err)
+		}
+
 		err = os.MkdirAll(path, 0o755)
 		if err != nil {
 			return Database{}, fmt.Errorf("failed to create database directory: %w", err)

--- a/pkg/database.go
+++ b/pkg/database.go
@@ -61,7 +61,7 @@ func getBranchName(s string) plumbing.ReferenceName {
 func remoteBranches(s storer.ReferenceStorer) (storer.ReferenceIter, error) {
 	refs, err := s.IterReferences()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to iterate references: %w", err)
 	}
 
 	return storer.NewReferenceFilteredIter(func(ref *plumbing.Reference) bool {
@@ -116,7 +116,7 @@ func (d Database) switchTag(repo *git.Repository, w *git.Worktree, rizinVersion 
 
 	err = w.Checkout(&git.CheckoutOptions{Branch: localBranchName, Create: create})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to checkout branch %s: %w", localBranchName, err)
 	}
 	return switchBranch, nil
 }
@@ -165,7 +165,7 @@ func (d Database) UpdateDatabase(rizinVersion string) error {
 			log.Printf("Failed to switch rz-pm-db to version %s, default to main branch", rizinVersion)
 			err = w.Checkout(&git.CheckoutOptions{Branch: "refs/heads/master"})
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to checkout master branch after failed switch to version %s: %w", rizinVersion, err)
 			}
 		} else {
 			log.Printf("Switched rz-pm-db to %s...\n", tagName)
@@ -207,7 +207,7 @@ func (d Database) ListAvailablePackages() ([]Package, error) {
 	dbPath := filepath.Join(d.Path, dbPath)
 	files, err := os.ReadDir(dbPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read available packages directory: %w", err)
 	}
 
 	packages := []Package{}
@@ -234,7 +234,7 @@ func (d Database) ListAvailablePackages() ([]Package, error) {
 func (d Database) GetPackage(name string) (Package, error) {
 	packages, err := d.ListAvailablePackages()
 	if err != nil {
-		return RizinPackage{}, err
+		return RizinPackage{}, fmt.Errorf("failed to list available packages: %w", err)
 	}
 
 	for _, pkg := range packages {

--- a/pkg/database.go
+++ b/pkg/database.go
@@ -124,13 +124,20 @@ func (d Database) switchTag(repo *git.Repository, w *git.Worktree, rizinVersion 
 func (d Database) UpdateDatabase(rizinVersion string) error {
 	repo, err := git.PlainOpen(d.Path)
 	if err == git.ErrRepositoryNotExists {
-		log.Printf("Downloading rz-pm-db repository...\n")
+		log.Println("Downloading rz-pm-db repository...")
 		repo, err = git.PlainClone(d.Path, false, &git.CloneOptions{
 			URL: RZPM_DB_REPO_URL,
 		})
 	}
 	if err != nil {
 		return fmt.Errorf("failed to open or clone rz-pm-db repository: %w", err)
+	}
+
+	// check that the db directory exists
+	dbDirPath := filepath.Join(d.Path, dbPath)
+	info, statErr := os.Stat(dbDirPath)
+	if statErr != nil || !info.IsDir() {
+		return fmt.Errorf("the cloned rz-pm-db repository does not contain a '%s' directory at %s", dbPath, dbDirPath)
 	}
 
 	w, err := repo.Worktree()

--- a/pkg/database.go
+++ b/pkg/database.go
@@ -130,22 +130,22 @@ func (d Database) UpdateDatabase(rizinVersion string) error {
 		})
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open or clone rz-pm-db repository: %w", err)
 	}
 
 	w, err := repo.Worktree()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get worktree: %w", err)
 	}
 	log.Printf("Updating rz-pm-db repository...\n")
 	err = w.Pull(&git.PullOptions{RemoteName: "origin"})
 	if err != git.NoErrAlreadyUpToDate {
-		return err
+		return fmt.Errorf("failed to pull rz-pm-db repository: %w", err)
 	}
 
 	h, err := repo.Head()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get repository head: %w", err)
 	}
 
 	branchName := h.Name().String()

--- a/pkg/envparse/parse.go
+++ b/pkg/envparse/parse.go
@@ -1,0 +1,79 @@
+package envparse
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func Unmarshal(input string, out any) error {
+	data := parseKeyValueString(input)
+
+	v := reflect.ValueOf(out)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("output must be a pointer to a struct")
+	}
+
+	v = v.Elem()
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("env")
+		if tag == "" {
+			continue
+		}
+
+		valueStr, ok := data[tag]
+		if !ok {
+			continue
+		}
+
+		fieldVal := v.Field(i)
+		if !fieldVal.CanSet() {
+			continue
+		}
+
+		switch fieldVal.Kind() {
+		case reflect.String:
+			fieldVal.SetString(valueStr)
+		case reflect.Int, reflect.Int64:
+			intVal, err := strconv.ParseInt(valueStr, 10, 64)
+			if err != nil {
+				return fmt.Errorf("error parsing int for field %s: %w", field.Name, err)
+			}
+			fieldVal.SetInt(intVal)
+		case reflect.Bool:
+			boolVal, err := strconv.ParseBool(valueStr)
+			if err != nil {
+				return fmt.Errorf("error parsing bool for field %s: %w", field.Name, err)
+			}
+			fieldVal.SetBool(boolVal)
+		default:
+			return fmt.Errorf("unsupported type %s for field %s", fieldVal.Kind(), field.Name)
+		}
+	}
+
+	return nil
+}
+
+// Parses a KEY=value formatted string
+func parseKeyValueString(input string) map[string]string {
+	result := make(map[string]string)
+	lines := strings.Split(input, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		result[key] = val
+	}
+	return result
+}

--- a/pkg/envparse/parse_test.go
+++ b/pkg/envparse/parse_test.go
@@ -1,0 +1,104 @@
+package envparse
+
+import (
+	"testing"
+)
+
+type testStruct struct {
+	Foo   string `env:"FOO"`
+	Bar   int    `env:"BAR"`
+	Baz   bool   `env:"BAZ"`
+	NoTag string
+}
+
+func TestUnmarshal_BasicTypes(t *testing.T) {
+	input := `
+FOO=hello
+BAR=42
+BAZ=true
+NOPE=should_be_ignored
+`
+	var ts testStruct
+	err := Unmarshal(input, &ts)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if ts.Foo != "hello" {
+		t.Errorf("expected Foo=hello, got %q", ts.Foo)
+	}
+	if ts.Bar != 42 {
+		t.Errorf("expected Bar=42, got %d", ts.Bar)
+	}
+	if ts.Baz != true {
+		t.Errorf("expected Baz=true, got %v", ts.Baz)
+	}
+	if ts.NoTag != "" {
+		t.Errorf("expected NoTag to be empty, got %q", ts.NoTag)
+	}
+}
+
+func TestUnmarshal_UnsupportedType(t *testing.T) {
+	type badStruct struct {
+		Foo float64 `env:"FOO"`
+	}
+	input := "FOO=3.14"
+	var bs badStruct
+	err := Unmarshal(input, &bs)
+	if err == nil {
+		t.Fatal("expected error for unsupported type, got nil")
+	}
+}
+
+func TestUnmarshal_IntError(t *testing.T) {
+	type s struct {
+		Bar int `env:"BAR"`
+	}
+	input := "BAR=notanint"
+	var st s
+	err := Unmarshal(input, &st)
+	if err == nil {
+		t.Fatal("expected error for int parse failure, got nil")
+	}
+}
+
+func TestUnmarshal_BoolError(t *testing.T) {
+	type s struct {
+		Baz bool `env:"BAZ"`
+	}
+	input := "BAZ=notabool"
+	var st s
+	err := Unmarshal(input, &st)
+	if err == nil {
+		t.Fatal("expected error for bool parse failure, got nil")
+	}
+}
+
+func TestUnmarshal_NonPointer(t *testing.T) {
+	input := "FOO=bar"
+	var ts testStruct
+	err := Unmarshal(input, ts) // not a pointer
+	if err == nil {
+		t.Fatal("expected error for non-pointer, got nil")
+	}
+}
+
+func TestUnmarshal_NonStructPointer(t *testing.T) {
+	input := "FOO=bar"
+	var s string
+	err := Unmarshal(input, &s)
+	if err == nil {
+		t.Fatal("expected error for non-struct pointer, got nil")
+	}
+}
+
+func TestUnmarshal_EmptyInput(t *testing.T) {
+	var ts testStruct
+	err := Unmarshal("", &ts)
+	if err != nil {
+		t.Fatalf("Unmarshal failed on empty input: %v", err)
+	}
+	// All fields should be zero values
+	if ts.Foo != "" || ts.Bar != 0 || ts.Baz != false {
+		t.Errorf("expected zero values, got %+v", ts)
+	}
+}

--- a/pkg/rizin/rizin.go
+++ b/pkg/rizin/rizin.go
@@ -1,0 +1,47 @@
+package rizin
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/rizinorg/rz-pm/pkg/envparse"
+)
+
+type RizinInfo struct {
+	Version      string `env:"RZ_VERSION"`
+	Prefix       string `env:"RZ_PREFIX"`
+	ExtraPrefix  string `env:"RZ_EXTRA_PREFIX"`
+	MagicPath    string `env:"RZ_MAGICPATH"`
+	IncDir       string `env:"RZ_INCDIR"`
+	LibDir       string `env:"RZ_LIBDIR"`
+	SigDB        string `env:"RZ_SIGDB"`
+	ExtraSigDB   string `env:"RZ_EXTRA_SIGDB"`
+	LibExt       string `env:"RZ_LIBEXT"`
+	ConfigHome   string `env:"RZ_CONFIGHOME"`
+	DataHome     string `env:"RZ_DATAHOME"`
+	CacheHome    string `env:"RZ_CACHEHOME"`
+	LibPlugins   string `env:"RZ_LIB_PLUGINS"`
+	ExtraPlugins string `env:"RZ_EXTRA_PLUGINS"`
+	UserPlugins  string `env:"RZ_USER_PLUGINS"`
+	IsPortable   string `env:"RZ_IS_PORTABLE"`
+}
+
+func GetRizinInfo() (RizinInfo, error) {
+	if _, err := exec.LookPath("rizin"); err != nil {
+		return RizinInfo{}, fmt.Errorf("rizin does not seem to be installed on your system. Make sure it is installed and in PATH")
+	}
+
+	cmd := exec.Command("rizin", "-H")
+	out, err := cmd.Output()
+	if err != nil {
+		return RizinInfo{}, fmt.Errorf("failed to run rizin: %w", err)
+	}
+
+	info := RizinInfo{}
+	err = envparse.Unmarshal(string(out), &info)
+	if err != nil {
+		return RizinInfo{}, fmt.Errorf("failed to parse rizin info: %w", err)
+	}
+
+	return info, nil
+}

--- a/pkg/rizin/rizin_test.go
+++ b/pkg/rizin/rizin_test.go
@@ -1,0 +1,101 @@
+package rizin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeRizinScript returns the contents of a bash script that mimics "rizin -H" output.
+func fakeRizinScript() string {
+	return `#!/bin/bash
+if [[ "$1" == "-H" ]]; then
+cat <<EOF
+RZ_VERSION=9.9.9-fake
+RZ_PREFIX=/fake/prefix
+RZ_EXTRA_PREFIX=/fake/extra
+RZ_MAGICPATH=/fake/magic
+RZ_INCDIR=/fake/include
+RZ_LIBDIR=/fake/lib
+RZ_SIGDB=/fake/sigdb
+RZ_EXTRA_SIGDB=/fake/extra_sigdb
+RZ_LIBEXT=.so
+RZ_CONFIGHOME=/fake/config
+RZ_DATAHOME=/fake/data
+RZ_CACHEHOME=/fake/cache
+RZ_LIB_PLUGINS=/fake/plugins
+RZ_EXTRA_PLUGINS=/fake/extra_plugins
+RZ_USER_PLUGINS=/fake/user_plugins
+RZ_IS_PORTABLE=0
+EOF
+else
+	echo "Unknown option" >&2
+	exit 1
+fi
+`
+}
+
+func TestGetRizinInfo_FakeExecutable(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeRizinPath := filepath.Join(tmpDir, "rizin")
+
+	// Write the fake rizin script
+	if err := os.WriteFile(fakeRizinPath, []byte(fakeRizinScript()), 0755); err != nil {
+		t.Fatalf("failed to write fake rizin: %v", err)
+	}
+
+	// Prepend tmpDir to PATH
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+origPath)
+
+	info, err := GetRizinInfo()
+	if err != nil {
+		t.Fatalf("GetRizinInfo failed: %v", err)
+	}
+
+	// Check a few fields for correctness
+	if info.Version != "9.9.9-fake" {
+		t.Errorf("expected Version=9.9.9-fake, got %q", info.Version)
+	}
+	if info.Prefix != "/fake/prefix" {
+		t.Errorf("expected Prefix=/fake/prefix, got %q", info.Prefix)
+	}
+	if info.LibExt != ".so" {
+		t.Errorf("expected LibExt=.so, got %q", info.LibExt)
+	}
+	if info.IsPortable != "0" {
+		t.Errorf("expected IsPortable=0, got %q", info.IsPortable)
+	}
+}
+
+func TestGetRizinInfo_NotInPath(t *testing.T) {
+	// Remove rizin from PATH
+	t.Setenv("PATH", "")
+
+	_, err := GetRizinInfo()
+	if err == nil {
+		t.Fatal("expected error when rizin is not in PATH, got nil")
+	}
+	if want := "rizin does not seem to be installed"; err == nil || err.Error()[:len(want)] != want {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetRizinInfo_FailsToRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeRizinPath := filepath.Join(tmpDir, "rizin")
+
+	// Write a script that always fails
+	script := "#!/bin/sh\nexit 42\n"
+	if err := os.WriteFile(fakeRizinPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write fake rizin: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+origPath)
+
+	_, err := GetRizinInfo()
+	if err == nil {
+		t.Fatal("expected error when rizin fails to run, got nil")
+	}
+}

--- a/pkg/updatecheck/updatecheck.go
+++ b/pkg/updatecheck/updatecheck.go
@@ -1,0 +1,50 @@
+// Package updatecheck provides helpers for periodic update
+// checks using a timestamp file.
+package updatecheck
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+// Checker manages update check timestamps in a file.
+type Checker struct {
+	Path     string
+	Interval time.Duration
+}
+
+// ShouldCheck returns true if enough time has passed since the last check,
+// or if no timestamp exists or cannot be parsed.
+func (c *Checker) ShouldCheck() (bool, error) {
+	data, err := os.ReadFile(c.Path)
+	if err != nil {
+		// If file doesn't exist, check for update
+		return true, nil
+	}
+	lastCheck, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
+	if err != nil {
+		// If parse fails, check for update
+		return true, nil
+	}
+	return time.Since(lastCheck) > c.Interval, nil
+}
+
+// UpdateTimestamp writes the current time to the file, creating parent directories if needed.
+func (c *Checker) UpdateTimestamp() error {
+	dir := getDir(c.Path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	now := time.Now().Format(time.RFC3339)
+	return os.WriteFile(c.Path, []byte(now), 0o644)
+}
+
+// getDir returns the directory part of the path.
+func getDir(path string) string {
+	lastSep := strings.LastIndexAny(path, "/\\")
+	if lastSep == -1 {
+		return "."
+	}
+	return path[:lastSep]
+}


### PR DESCRIPTION
Introduce updatecheck package to track last update times and skip unnecessary checks.

Refactor database and site initialization to not execute the rizin executable multiple times.