### PR TITLE
go ver bump and fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Build the Go binary
         run: go build
       - name: Make sure jsdec is present in the database
-        run: ./rz-pm list | grep -q 'Converts asm to pseudo-C code'
+        run: ./rz-pm --skip-upgrade info jsdec
       - name: Install jsdec
-        run: ./rz-pm install jsdec
+        run: ./rz-pm --skip-upgrade install jsdec
       - name: Check jsdec
         run: ls $(rizin -H RZ_USER_PLUGINS) | grep core_pdd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
             cgo_enabled: 1
             cc: /tmp/android-ndk/android-ndk-r21e/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.25
         uses: actions/setup-go@v6
         with:
-          go-version: '1.19'
+          go-version: '1.25'
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ const (
 	flagUpdateDB    = "update-db"
 )
 
+var initSite = pkg.InitSite
+
 func setDebug(value bool) {
 	if value {
 		log.SetOutput(os.Stderr)
@@ -37,7 +39,7 @@ func listPackages(c *cli.Context, installed bool) error {
 		return fmt.Errorf("wrong usage of list command")
 	}
 
-	site, err := pkg.InitSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
+	site, err := initSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
 	if err != nil {
 		return err
 	}
@@ -86,7 +88,7 @@ func infoPackage(c *cli.Context) error {
 		return fmt.Errorf("wrong usage of info command")
 	}
 
-	site, err := pkg.InitSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
+	site, err := initSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
 	if err != nil {
 		return err
 	}
@@ -206,16 +208,19 @@ func installPackages(c *cli.Context) error {
 		cli.ShowCommandHelp(c, "install")
 		return fmt.Errorf("wrong usage of install command")
 	}
+
+	site, err := initSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
+	if err != nil {
+		return err
+	}
+	//multi-package installs shouldn't trigger site lock, so reused same instance
+	defer site.Close()
+
 	for _, packageName := range c.Args().Slice() {
 		if packageName == "" {
 			cli.ShowCommandHelp(c, "install")
 			return fmt.Errorf("wrong usage of install command")
 		}
-		site, err := pkg.InitSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
-		if err != nil {
-			return err
-		}
-		defer site.Close()
 
 		var pkg pkg.Package
 		if c.Bool("file") {
@@ -244,17 +249,19 @@ func uninstallPackages(c *cli.Context) error {
 		cli.ShowCommandHelp(c, "uninstall")
 		return fmt.Errorf("wrong usage of uninstall command")
 	}
+
+	site, err := initSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
+	if err != nil {
+		return err
+	}
+	//same as in install above
+	defer site.Close()
+
 	for _, packageName := range c.Args().Slice() {
 		if packageName == "" {
 			cli.ShowCommandHelp(c, "uninstall")
 			return fmt.Errorf("wrong usage of uninstall command")
 		}
-
-		site, err := pkg.InitSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
-		if err != nil {
-			return err
-		}
-		defer site.Close()
 
 		var pkg pkg.Package
 		if c.Bool("file") {
@@ -281,7 +288,7 @@ func cleanPackage(c *cli.Context) error {
 		return fmt.Errorf("wrong usage of clean command")
 	}
 
-	site, err := pkg.InitSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
+	site, err := initSite(pkg.SiteDir(), c.Bool(flagUpdateDB))
 	if err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	rzpmPkg "github.com/rizinorg/rz-pm/pkg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+type fakeCLIPackage struct {
+	name string
+}
+
+func (p fakeCLIPackage) Name() string                           { return p.name }
+func (p fakeCLIPackage) Version() string                        { return "0.0.1" }
+func (p fakeCLIPackage) Summary() string                        { return "" }
+func (p fakeCLIPackage) Description() string                    { return "" }
+func (p fakeCLIPackage) Source() rzpmPkg.RizinPackageSource     { return rzpmPkg.RizinPackageSource{} }
+func (p fakeCLIPackage) Download(string) error                  { return nil }
+func (p fakeCLIPackage) Build(rzpmPkg.Site) error               { return nil }
+func (p fakeCLIPackage) Install(rzpmPkg.Site) ([]string, error) { return nil, nil }
+func (p fakeCLIPackage) Uninstall(rzpmPkg.Site) error           { return nil }
+
+type fakeCLISite struct {
+	packages        map[string]rzpmPkg.Package
+	installCalls    []string
+	uninstallCalls  []string
+	cleanCalls      []string
+	closeCalls      int
+	getPackageCalls []string
+}
+
+func (s *fakeCLISite) ListAvailablePackages() ([]rzpmPkg.Package, error) {
+	return []rzpmPkg.Package{}, nil
+}
+func (s *fakeCLISite) ListInstalledPackages() ([]rzpmPkg.Package, error) {
+	return []rzpmPkg.Package{}, nil
+}
+func (s *fakeCLISite) IsPackageInstalled(rzpmPkg.Package) bool { return false }
+func (s *fakeCLISite) GetPackage(name string) (rzpmPkg.Package, error) {
+	s.getPackageCalls = append(s.getPackageCalls, name)
+	pkg, ok := s.packages[name]
+	if !ok {
+		return nil, fmt.Errorf("package %s not found", name)
+	}
+	return pkg, nil
+}
+func (s *fakeCLISite) GetPackageFromFile(string) (rzpmPkg.Package, error) { return nil, nil }
+func (s *fakeCLISite) GetInstalledPackage(string) (rzpmPkg.InstalledPackage, error) {
+	return rzpmPkg.InstalledPackage{}, nil
+}
+func (s *fakeCLISite) GetBaseDir() string      { return "" }
+func (s *fakeCLISite) GetArtifactsDir() string { return "" }
+func (s *fakeCLISite) GetPkgConfigDir() string { return "" }
+func (s *fakeCLISite) GetCMakeDir() string     { return "" }
+func (s *fakeCLISite) InstallPackage(pkg rzpmPkg.Package) error {
+	s.installCalls = append(s.installCalls, pkg.Name())
+	return nil
+}
+func (s *fakeCLISite) UninstallPackage(pkg rzpmPkg.Package) error {
+	s.uninstallCalls = append(s.uninstallCalls, pkg.Name())
+	return nil
+}
+func (s *fakeCLISite) CleanPackage(pkg rzpmPkg.Package) error {
+	s.cleanCalls = append(s.cleanCalls, pkg.Name())
+	return nil
+}
+func (s *fakeCLISite) Remove() error        { return nil }
+func (s *fakeCLISite) RizinVersion() string { return "0.9.0" }
+func (s *fakeCLISite) Close() error         { s.closeCalls++; return nil }
+
+func newCLIContext(t *testing.T, args []string, includeClean bool) *cli.Context {
+	t.Helper()
+
+	flagSet := flag.NewFlagSet("rz-pm-test", flag.ContinueOnError)
+	flagSet.Bool(flagUpdateDB, true, "")
+	flagSet.Bool("file", false, "")
+	if includeClean {
+		flagSet.Bool("clean", false, "")
+	}
+	require.NoError(t, flagSet.Parse(args))
+
+	app := cli.NewApp()
+	return cli.NewContext(app, flagSet, nil)
+}
+
+func TestInstallPackagesUsesSingleSite(t *testing.T) {
+	originalInitSite := initSite
+	defer func() { initSite = originalInitSite }()
+
+	site := &fakeCLISite{
+		packages: map[string]rzpmPkg.Package{
+			"first":  fakeCLIPackage{name: "first"},
+			"second": fakeCLIPackage{name: "second"},
+		},
+	}
+	initCalls := 0
+	initSite = func(string, bool) (rzpmPkg.Site, error) {
+		initCalls++
+		return site, nil
+	}
+
+	//reusing same site for whole cmd, where it's multi-pkg
+	err := installPackages(newCLIContext(t, []string{"--clean", "first", "second"}, true))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, initCalls, "site should be initialized once for a multi-package install")
+	assert.Equal(t, 1, site.closeCalls, "site should be closed once")
+	assert.Equal(t, []string{"first", "second"}, site.getPackageCalls)
+	assert.Equal(t, []string{"first", "second"}, site.cleanCalls)
+	assert.Equal(t, []string{"first", "second"}, site.installCalls)
+}
+
+func TestUninstallPackagesUsesSingleSite(t *testing.T) {
+	originalInitSite := initSite
+	defer func() { initSite = originalInitSite }()
+
+	site := &fakeCLISite{
+		packages: map[string]rzpmPkg.Package{
+			"first":  fakeCLIPackage{name: "first"},
+			"second": fakeCLIPackage{name: "second"},
+		},
+	}
+	initCalls := 0
+	initSite = func(string, bool) (rzpmPkg.Site, error) {
+		initCalls++
+		return site, nil
+	}
+
+	//same as in install above
+	err := uninstallPackages(newCLIContext(t, []string{"first", "second"}, false))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, initCalls, "site should be initialized once for a multi-package uninstall")
+	assert.Equal(t, 1, site.closeCalls, "site should be closed once")
+	assert.Equal(t, []string{"first", "second"}, site.getPackageCalls)
+	assert.Equal(t, []string{"first", "second"}, site.uninstallCalls)
+}

--- a/pkg/database.go
+++ b/pkg/database.go
@@ -121,7 +121,8 @@ func (d Database) updateDatabase(rizinVersion string) error {
 	}
 	log.Printf("Updating rz-pm-db repository...\n")
 	err = w.Pull(&git.PullOptions{RemoteName: "origin"})
-	if err != git.NoErrAlreadyUpToDate {
+	//below branch selction logic should also be used for a sucessfull pull, for a non-default branch
+	if err != nil && err != git.NoErrAlreadyUpToDate {
 		return err
 	}
 
@@ -165,15 +166,17 @@ func ParsePackageFile(path string) (Package, error) {
 	if p.PackageName == "" || p.PackageVersion == "" || p.PackageSummary == "" {
 		return RizinPackage{}, fmt.Errorf("wrong file plugin format: name, version, and summary are mandatory")
 	}
-	if p.PackageSource != nil {
-		if p.PackageSource.URL == "" || p.PackageSource.BuildSystem == "" {
-			return RizinPackage{}, fmt.Errorf("wrong file plugin format: Source URL and Build System are mandatory")
-		}
-		if !p.isGitRepo() && p.PackageSource.Hash == "" {
-			return RizinPackage{}, fmt.Errorf("wrong file plugin format: Source Hash is mandatory for non-git plugins")
-		} else if p.isGitRepo() && p.PackageSource.Hash != "" {
-			return RizinPackage{}, fmt.Errorf("wrong file plugin format: Source Hash should not be used for git plugins")
-		}
+	//as every installable package needs a source.
+	if p.PackageSource == nil {
+		return RizinPackage{}, fmt.Errorf("wrong file plugin format: source is mandatory")
+	}
+	if p.PackageSource.URL == "" || p.PackageSource.BuildSystem == "" {
+		return RizinPackage{}, fmt.Errorf("wrong file plugin format: Source URL and Build System are mandatory")
+	}
+	if !p.isGitRepo() && p.PackageSource.Hash == "" {
+		return RizinPackage{}, fmt.Errorf("wrong file plugin format: Source Hash is mandatory for non-git plugins")
+	} else if p.isGitRepo() && p.PackageSource.Hash != "" {
+		return RizinPackage{}, fmt.Errorf("wrong file plugin format: Source Hash should not be used for git plugins")
 	}
 	return p, nil
 }

--- a/pkg/package.go
+++ b/pkg/package.go
@@ -25,6 +25,7 @@ type BuildSystem string
 
 const (
 	Meson BuildSystem = "meson"
+	CMake BuildSystem = "cmake"
 )
 
 type RizinPackageSource struct {
@@ -72,15 +73,41 @@ func (rp RizinPackage) Summary() string {
 }
 
 func (rp RizinPackage) Source() RizinPackageSource {
+	if rp.PackageSource == nil {
+		return RizinPackageSource{}
+	}
 	return *rp.PackageSource
 }
 
 func (rp RizinPackage) isGitRepo() bool {
-	return rp.PackageSource == nil || strings.HasSuffix(rp.PackageSource.URL, ".git")
+	return rp.PackageSource != nil && strings.HasSuffix(rp.PackageSource.URL, ".git")
 }
 
 func (rp RizinPackage) isSupportedArchiveRepo() bool {
-	return rp.PackageSource == nil || strings.HasSuffix(rp.PackageSource.URL, ".tar.gz") || strings.HasSuffix(rp.PackageSource.URL, ".tar")
+	return rp.PackageSource != nil && (strings.HasSuffix(rp.PackageSource.URL, ".tar.gz") || strings.HasSuffix(rp.PackageSource.URL, ".tar"))
+}
+
+func (rp RizinPackage) validateSource() error {
+	//fail here instead of letting nil source data break later steps
+	if rp.PackageSource == nil {
+		return fmt.Errorf("package %s does not define a source", rp.PackageName)
+	}
+	return nil
+}
+
+func secureJoin(basePath, relativePath string) (string, error) {
+	cleanBase := filepath.Clean(basePath)
+	targetPath := filepath.Clean(filepath.Join(cleanBase, relativePath))
+
+	relPath, err := filepath.Rel(cleanBase, targetPath)
+	if err != nil {
+		return "", err
+	}
+	//reject paths that escape the extraction root, including sibling-prefix traversal cases.
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) || filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("trying to extract a file outside the base path")
+	}
+	return targetPath, nil
 }
 
 func (rp RizinPackage) downloadTar(artifactsPath string) error {
@@ -107,6 +134,7 @@ func (rp RizinPackage) downloadTar(artifactsPath string) error {
 	if err != nil {
 		return err
 	}
+	defer tarballFileOpen.Close()
 
 	content, err := io.ReadAll(tarballFileOpen)
 	if err != nil {
@@ -142,10 +170,9 @@ func (rp RizinPackage) downloadTar(artifactsPath string) error {
 			return err
 		}
 
-		filename := filepath.Join(artifactsPath, header.Name)
-		cleanedFilename := filepath.Clean(filename)
-		if !strings.HasPrefix(cleanedFilename, artifactsPath) {
-			return fmt.Errorf("trying to extract a file outside the base path")
+		filename, err := secureJoin(artifactsPath, header.Name)
+		if err != nil {
+			return err
 		}
 
 		switch header.Typeflag {
@@ -156,20 +183,30 @@ func (rp RizinPackage) downloadTar(artifactsPath string) error {
 				return err
 			}
 		case tar.TypeReg:
-			// handle normal file
+			//create parent directories explicitly so nested archive entries extract reliably.
+			err = os.MkdirAll(filepath.Dir(filename), 0755)
+			if err != nil {
+				return err
+			}
+
 			writer, err := os.Create(filename)
 			if err != nil {
 				return err
 			}
 
-			io.Copy(writer, tarballReader)
+			_, err = io.Copy(writer, tarballReader)
+			closeErr := writer.Close()
+			if err != nil {
+				return err
+			}
+			if closeErr != nil {
+				return closeErr
+			}
 
 			err = os.Chmod(filename, os.FileMode(header.Mode))
 			if err != nil {
 				return err
 			}
-
-			writer.Close()
 		}
 	}
 	fmt.Printf("Source code for %s downloaded and extracted.\n", rp.PackageName)
@@ -210,9 +247,14 @@ func (rp RizinPackage) downloadGit(artifactsPath string) error {
 
 // Download the source code of a package and extract it in the provided path
 func (rp RizinPackage) Download(baseArtifactsPath string) error {
+	err := rp.validateSource()
+	if err != nil {
+		return err
+	}
+
 	log.Printf("Downloading package %s... from '%s'", rp.PackageName, rp.PackageSource.URL)
 	artifactsPath := rp.artifactsPath(baseArtifactsPath)
-	err := os.MkdirAll(artifactsPath, os.FileMode(0755))
+	err = os.MkdirAll(artifactsPath, os.FileMode(0755))
 	if err != nil {
 		return err
 	}
@@ -253,7 +295,6 @@ func (rp RizinPackage) buildMeson(site Site) error {
 	log.Printf("Running meson setup:")
 	log.Printf("\tdir: %s", srcPath)
 	log.Printf("\targs: %s", strings.Join(args, " "))
-
 
 	if err := cmd.Run(); err != nil {
 		return err
@@ -375,6 +416,10 @@ func buildErrorMsg(msg string) string {
 
 // Build a package if a source is provided
 func (rp RizinPackage) Build(site Site) error {
+	if err := rp.validateSource(); err != nil {
+		return err
+	}
+
 	if site.GetPkgConfigDir() == "" && site.GetCMakeDir() == "" {
 		return fmt.Errorf("make sure rizin development files are installed (e.g. librizin-dev, rizin-devel, etc.)")
 	}
@@ -389,7 +434,8 @@ func (rp RizinPackage) Build(site Site) error {
 	}
 
 	fmt.Printf("Building %s...\n", rp.PackageName)
-	if rp.PackageSource.BuildSystem == "meson" {
+	switch rp.PackageSource.BuildSystem {
+	case Meson:
 		_, err := exec.LookPath("meson")
 		if err != nil {
 			return fmt.Errorf("%s", buildErrorMsg("make sure 'meson' is installed and in PATH"))
@@ -404,7 +450,7 @@ func (rp RizinPackage) Build(site Site) error {
 		}
 
 		return rp.buildMeson(site)
-	} else if rp.PackageSource.BuildSystem == "cmake" {
+	case CMake:
 		_, err := exec.LookPath("cmake")
 		if err != nil {
 			return fmt.Errorf("%s", buildErrorMsg("make sure 'cmake' is installed and in PATH"))
@@ -416,7 +462,7 @@ func (rp RizinPackage) Build(site Site) error {
 		}
 
 		return rp.buildCMake(site)
-	} else {
+	default:
 		log.Printf("BuildSystem %s is not supported yet.", rp.PackageSource.BuildSystem)
 		return fmt.Errorf("unsupported build system")
 	}
@@ -424,6 +470,10 @@ func (rp RizinPackage) Build(site Site) error {
 
 // Install a package after building it
 func (rp RizinPackage) Install(site Site) ([]string, error) {
+	if err := rp.validateSource(); err != nil {
+		return []string{}, err
+	}
+
 	err := rp.Build(site)
 	if err != nil {
 		return []string{}, err
@@ -431,11 +481,12 @@ func (rp RizinPackage) Install(site Site) ([]string, error) {
 
 	var installed_files []string
 	fmt.Printf("Installing %s...\n", rp.PackageName)
-	if rp.PackageSource.BuildSystem == "meson" {
+	switch rp.PackageSource.BuildSystem {
+	case Meson:
 		installed_files, err = rp.installMeson(site)
-	} else if rp.PackageSource.BuildSystem == "cmake" {
+	case CMake:
 		installed_files, err = rp.installCMake(site)
-	} else {
+	default:
 		log.Printf("BuildSystem %s is not supported yet.", rp.PackageSource.BuildSystem)
 		err = fmt.Errorf("unsupported build system")
 	}
@@ -447,11 +498,16 @@ func (rp RizinPackage) Install(site Site) ([]string, error) {
 }
 
 func (rp RizinPackage) Uninstall(site Site) error {
+	if err := rp.validateSource(); err != nil {
+		return err
+	}
+
 	fmt.Printf("Uninstalling %s...\n", rp.PackageName)
 	var err error
-	if rp.PackageSource.BuildSystem == "meson" {
+	switch rp.PackageSource.BuildSystem {
+	case Meson:
 		err = rp.uninstallMeson(site)
-	} else {
+	default:
 		log.Printf("BuildSystem %s is not supported yet.", rp.PackageSource.BuildSystem)
 		err = fmt.Errorf("unsupported build system")
 	}

--- a/pkg/package_test.go
+++ b/pkg/package_test.go
@@ -7,11 +7,11 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -28,7 +28,7 @@ func TestDownloadSimplePackage(t *testing.T) {
 		PackageSource: &RizinPackageSource{
 			URL:            "https://github.com/rizinorg/jsdec/archive/refs/tags/v0.4.0.tar.gz",
 			Hash:           "5afe9a823c1c31ccf641dc1667a092418cd84f5cb9865730580783ca7c44e93d",
-			BuildSystem:    "meson",
+			BuildSystem:    Meson,
 			Directory:      "p",
 			BuildArguments: []string{"-Djsc_folder=.."},
 		},
@@ -54,7 +54,7 @@ func TestWrongHash(t *testing.T) {
 		PackageSource: &RizinPackageSource{
 			URL:            "https://github.com/rizinorg/jsdec/archive/refs/tags/v0.8.0.tar.gz",
 			Hash:           "sha256:2b2587dd117d48b284695416a7349a21c4dd30fbe75cc5890ed74945c9b474aa",
-			BuildSystem:    "meson",
+			BuildSystem:    Meson,
 			Directory:      "p",
 			BuildArguments: []string{"-Djsc_folder=.."},
 		},
@@ -74,6 +74,8 @@ func TestWrongHash(t *testing.T) {
 
 type FakeSite struct {
 	ArtifactsDir string
+	PkgConfigDir string
+	CMakeDir     string
 }
 
 func (s FakeSite) GetInstalledPackage(string) (InstalledPackage, error) {
@@ -87,13 +89,42 @@ func (s FakeSite) GetPackageFromFile(filename string) (Package, error) { return 
 func (s FakeSite) GetBaseDir() string                                  { return "" }
 func (s FakeSite) RizinVersion() string                                { return "0.5.2" }
 func (s FakeSite) GetArtifactsDir() string                             { return s.ArtifactsDir }
-func (s FakeSite) GetPkgConfigDir() string                             { return "pkg-config-dir" }
-func (s FakeSite) GetCMakeDir() string                                 { return "" }
+func (s FakeSite) GetPkgConfigDir() string                             { return s.PkgConfigDir }
+func (s FakeSite) GetCMakeDir() string                                 { return s.CMakeDir }
 func (s FakeSite) InstallPackage(Package) error                        { return nil }
 func (s FakeSite) UninstallPackage(Package) error                      { return nil }
 func (s FakeSite) CleanPackage(Package) error                          { return nil }
 func (s FakeSite) Remove() error                                       { return nil }
 func (s FakeSite) Close() error                                        { return nil }
+
+func newBuildTestSite(t *testing.T, artifactsDir string) FakeSite {
+	t.Helper()
+
+	if _, err := exec.LookPath("meson"); err != nil {
+		t.Skip("meson is required for build/install package tests")
+	}
+	//mirror the real build prerequisites so test failures reflect product behavior
+	if _, err := exec.LookPath("pkg-config"); err != nil {
+		if _, cmakeErr := exec.LookPath("cmake"); cmakeErr != nil {
+			t.Skip("either pkg-config or cmake is required for build/install package tests")
+		}
+	}
+
+	pkgConfigDir, pkgConfigErr := getPkgConfigPath()
+	cmakeDir, cmakeErr := getCMakePath()
+	if pkgConfigErr != nil && cmakeErr != nil {
+		t.Skipf("rizin development files are required for build/install package tests: pkg-config path error: %v, cmake path error: %v", pkgConfigErr, cmakeErr)
+	}
+	if pkgConfigDir == "" && cmakeDir == "" {
+		t.Skip("rizin development files are required for build/install package tests")
+	}
+
+	return FakeSite{
+		ArtifactsDir: artifactsDir,
+		PkgConfigDir: pkgConfigDir,
+		CMakeDir:     cmakeDir,
+	}
+}
 
 // tarGzDir creates a .tar.gz archive at destFile containing the contents of srcDir.
 func tarGzDir(destFile, srcDir string) error {
@@ -212,13 +243,39 @@ func createTestPackage(t *testing.T, ctx context.Context) RizinPackage {
 		PackageSource: &RizinPackageSource{
 			URL:            serveURL,
 			Hash:           hash,
-			BuildSystem:    "meson",
+			BuildSystem:    Meson,
 			Directory:      "",
 			BuildArguments: []string{"-Drizin_plugdir="},
 		},
 	}
 
 	return simplePackage
+}
+
+func createMaliciousTarGz(t *testing.T, parentDir string, version string) string {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp(parentDir, "rzpm-malicious-*.tar.gz")
+	require.NoError(t, err, "temp tarball should be created")
+
+	gw := gzip.NewWriter(tmpFile)
+	tw := tar.NewWriter(gw)
+
+	payload := []byte("escaped")
+	header := &tar.Header{
+		Name: fmt.Sprintf("../%sX/evil.txt", version),
+		Mode: 0600,
+		Size: int64(len(payload)),
+	}
+	require.NoError(t, tw.WriteHeader(header), "malicious tar header should be written")
+	_, err = tw.Write(payload)
+	require.NoError(t, err, "malicious tar payload should be written")
+
+	require.NoError(t, tw.Close(), "malicious tar should be finalized")
+	require.NoError(t, gw.Close(), "malicious gzip should be finalized")
+	require.NoError(t, tmpFile.Close(), "malicious tarball should be closed")
+
+	return tmpFile.Name()
 }
 
 func TestInstallSimplePackage(t *testing.T) {
@@ -239,7 +296,7 @@ func TestInstallSimplePackage(t *testing.T) {
 	err = p.Download(tmpPath)
 	require.NoError(t, err, "package should be downloaded")
 
-	installedFiles, err := p.Install(FakeSite{ArtifactsDir: tmpPath})
+	installedFiles, err := p.Install(newBuildTestSite(t, tmpPath))
 	require.NoError(t, err, "The plugin should be built and installed without errors")
 
 	files, err := os.ReadDir(pluginsPath)
@@ -294,14 +351,14 @@ func TestUninstallSimplePackage(t *testing.T) {
 	err = p.Download(tmpPath)
 	require.NoError(t, err, "package should be downloaded")
 
-	s := FakeSite{ArtifactsDir: tmpPath}
+	s := newBuildTestSite(t, tmpPath)
 	_, err = p.Install(s)
 	assert.NoError(t, err, "The plugin should be built and installed without errors")
 
 	err = p.Uninstall(s)
 	assert.NoError(t, err, "The plugin should be uninstalled without errors")
 
-	files, err := ioutil.ReadDir(pluginsPath)
+	files, err := os.ReadDir(pluginsPath)
 	require.NoError(t, err, "pluginsPath should be read")
 	require.Len(t, files, 0, "there should be one plugins installed")
 }
@@ -313,7 +370,7 @@ func TestDownloadGitPackage(t *testing.T) {
 		PackageVersion:     "dev",
 		PackageSource: &RizinPackageSource{
 			URL:            "https://github.com/rizinorg/jsdec.git",
-			BuildSystem:    "meson",
+			BuildSystem:    Meson,
 			Directory:      "",
 			BuildArguments: []string{"-Dstandalone=false"},
 		},
@@ -331,4 +388,46 @@ func TestDownloadGitPackage(t *testing.T) {
 	assert.NoError(t, err, "simple-git(jsdec) master branch should have been git cloned")
 	_, err = os.Stat(filepath.Join(tmpPath, "simple-git", "dev", "jsdec", "c"))
 	assert.NoError(t, err, "simple-git(jsdec)c should be there")
+}
+
+func TestDownloadTarRejectsPathTraversal(t *testing.T) {
+	parentDir, err := os.MkdirTemp(os.TempDir(), "rzpmtest-traversal")
+	require.NoError(t, err, "temp parent path should be created")
+	defer os.RemoveAll(parentDir)
+
+	tarball := createMaliciousTarGz(t, parentDir, "0.0.1")
+	hash := calcFileSha256(t, tarball)
+	server := http.Server{
+		Addr: "127.0.0.1:0",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.ServeFile(w, r, tarball)
+		}),
+	}
+
+	ln, err := net.Listen("tcp", server.Addr)
+	require.NoError(t, err, "malicious test server should listen")
+	defer server.Shutdown(context.Background())
+
+	go server.Serve(ln)
+
+	p := RizinPackage{
+		PackageName:        "simple",
+		PackageDescription: "simple description",
+		PackageVersion:     "0.0.1",
+		PackageSource: &RizinPackageSource{
+			URL:         fmt.Sprintf("http://%s/malicious.tar.gz", ln.Addr().String()),
+			Hash:        hash,
+			BuildSystem: Meson,
+			Directory:   "",
+		},
+	}
+
+	baseArtifactsPath := filepath.Join(parentDir, "artifacts")
+	err = p.Download(baseArtifactsPath)
+	require.ErrorContains(t, err, "outside the base path")
+
+	// The malicious tarball targets a sibling path that used to bypass string-prefix checks.
+	escapedPath := filepath.Join(baseArtifactsPath, "simple", "0.0.1X", "evil.txt")
+	_, err = os.Stat(escapedPath)
+	assert.True(t, os.IsNotExist(err), "path traversal should not create files outside the package directory")
 }

--- a/pkg/site_test.go
+++ b/pkg/site_test.go
@@ -141,22 +141,39 @@ version: 0.0.1
 summary: simple description
 `
 
+	f4 := `name: simple
+version: 0.0.1
+summary: simple description
+source:
+  directory: jsdec-0.7.0/
+`
+
 	tmpFile.WriteString(f1)
 
 	_, err = ParsePackageFile(tmpFile.Name())
 	assert.Error(t, err, "missing name should fail parsing")
 
 	tmpFile.Truncate(0)
+	//seek to start before rewriting, so no residual data from previous case stays
+	tmpFile.Seek(0, 0)
 	tmpFile.WriteString(f2)
 
 	_, err = ParsePackageFile(tmpFile.Name())
 	assert.Error(t, err, "missing version should fail parsing")
 
 	tmpFile.Truncate(0)
+	tmpFile.Seek(0, 0)
 	tmpFile.WriteString(f3)
 
 	_, err = ParsePackageFile(tmpFile.Name())
 	assert.Error(t, err, "missing source should fail parsing")
+
+	tmpFile.Truncate(0)
+	tmpFile.Seek(0, 0)
+	tmpFile.WriteString(f4)
+
+	_, err = ParsePackageFile(tmpFile.Name())
+	assert.Error(t, err, "source with missing url and build_system should fail parsing")
 }
 
 type FakePackage struct {


### PR DESCRIPTION
bumps go ver in release workflow to same as in go.mod (1.25)
fixes rz-pm-db post-pull branch selection
resolves multi pkg cli self locking in install and uninstall
hardens tar extraction against path traversal
aligns manifest parsing with runtime source requirements
adds/improves test(s) to cover the updated behaviour
(& a minor CI change - https://github.com/rizinorg/rz-pm/pull/92/commits/198a7051386daafa549bbd02c71d86b21be56f66, passing- https://github.com/IndAlok/rz-pm/actions/runs/23944473261)